### PR TITLE
Add reproduction code link to RadarPillars entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@
     - **:book:Note:** 
 26. **RadarPillars: Efficient Object Detection from 4D Radar Point Clouds (24'arXiv)**
 
-    - **:link:Link:** [paper](https://arxiv.org/pdf/2408.05020)
+    - **:link:Link:** [paper](https://arxiv.org/pdf/2408.05020) [code](https://github.com/fthbng77/RadarPillar)
     - **:school:Affiliation:** Mannheim University of Applied Sciences, Germany
     - **:file_folder:Dataset:** VoD
-    - **:book:Note:** 
+    - **:book:Note:** Unofficial open-source reproduction on VoD reproduces and exceeds the paper (mAP_3D 52.56 vs 50.70, R11); pretrained weights included.
 27. **CenterRadarNet: Joint 3D Object Detection and Tracking Framework using 4D FMCW Radar (24'ICIP)**
 
     - **:link:Link:** [paper](https://ieeexplore.ieee.org/abstract/document/10648077) 


### PR DESCRIPTION
The RadarPillars entry currently has no code link, since the original authors did not release code.

I'm adding an unofficial open-source reproduction on the View-of-Delft dataset, which reproduces and exceeds the published result (mAP_3D 52.56 vs 50.70, R11) and ships pretrained weights:

https://github.com/fthbng77/RadarPillar

This fills the empty code and note fields for entry 26.